### PR TITLE
ci: add auto-merge workflow for dependabot PR

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,18 @@
+name: Auto merge
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge-dependabot:
+    runs-on: ubuntu-20.04
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Auto merge PR
+        uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          github-token: ${{ secrets.OKP4_TOKEN }}


### PR DESCRIPTION
## 🤖 Auto merge dependabot PR

Implements new GitHub Actions workflow triggered on `pull_request` events to auto merge `dependabot` PR targeting patch & minor version updates.