### PR TITLE
ci: add graphql schema inspector

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -155,3 +155,4 @@ jobs:
         uses: kamilkisiela/graphql-inspector@v3.1.2
         with:
           schema: 'main:graph/schema.graphqls'
+          fail-on-breaking: false


### PR DESCRIPTION
#### 📝 Description

Add [graphql-inspector](https://www.graphql-inspector.com/docs/products/action) allowing check schema on GitHub action and report any graphql schema changes and alert if there are breaking changes.

I've let the default parameters, like fails check if there are breaking changes.

@ccamel Once the PR is merged, I will add this check action on the [okp4/actions](https://github.com/okp4/actions/pull/1) repo. 