### PR TITLE
ci(publish): do not trigger on PR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,9 +5,6 @@ on:
     branches: [ main ]
     tags: [ "v*" ]
 
-  pull_request:
-    branches: [ main ]
-
 concurrency:
   group: publish-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Remove the pull request trigger on publish workflow, I don't think it is relevant.. And it causes some troubles with dependabot PRs.