### PR TITLE
🧪 add upload of coverage to code coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,12 @@ jobs:
       - name: Test go project
         run: |
           make test-go
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        if: github.actor != 'dependabot[bot]'
+        with:
+          files: ./target/coverage.txt
+          env_vars: OS,GOLANG
+          fail_ci_if_error: true
+          verbose: true

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ test: test-go ## Pass all the tests
 
 test-go: build ## Pass the test for the go source code
 	@echo "${COLOR_CYAN} 🧪 Passing go tests${COLOR_RESET}"
-	@go test -v -covermode=count -coverprofile ./target/coverage.out ./...
+	@go test -v -coverprofile ./target/coverage.txt ./...
 
 ## Help:
 help: ## Show this help.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![lint](https://github.com/okp4/cosmos-faucet/actions/workflows/lint.yml/badge.svg)](https://github.com/okp4/cosmos-faucet/actions/workflows/lint.yml)
 [![test](https://github.com/okp4/cosmos-faucet/actions/workflows/test.yml/badge.svg)](https://github.com/okp4/cosmos-faucet/actions/workflows/test.yml)
 [![maintainability](https://api.codeclimate.com/v1/badges/b2b9effa4c2f43ffbf3d/maintainability)](https://codeclimate.com/github/okp4/cosmos-faucet/maintainability)
-[![test coverage](https://api.codeclimate.com/v1/badges/b2b9effa4c2f43ffbf3d/test_coverage)](https://codeclimate.com/github/okp4/cosmos-faucet/test_coverage)
+[![coverage](https://codecov.io/gh/okp4/cosmos-faucet/branch/main/graph/badge.svg?token=0VQHJDMY5B)](https://codecov.io/gh/okp4/cosmos-faucet)
 [![conventional commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 [![license](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 


### PR DESCRIPTION
Follow #27, add the upload of the [tests coverage](https://app.codecov.io/gh/okp4/cosmos-faucet) to [Codecov](https://about.codecov.io) (was missing).