### PR TITLE
ci(publish): add @okp4 scope to npm package

### DIFF
--- a/.github/package.json
+++ b/.github/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "cosmos-faucet-schema",
+    "name": "@okp4/cosmos-faucet-schema",
     "version": "0.0.0",
     "private": false,
     "description": "Cosmos Faucet GraphQL schema.",


### PR DESCRIPTION
Add the missing `@okp4` scope to the npm package.