### PR TITLE
ci(publish): specify public access for npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           cp .github/package.json package.json
           DATE=$(date +%Y%m%d%H%M%S)
-          publish=(npm publish)
+          publish=(npm publish --access=public)
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
             publish+=(--tag latest)
           else


### PR DESCRIPTION
Specify the public access when publishing npm package, which is needed when publishing a scoped package for the first time..

Sorry for the PR spam, really hate npm...