### PR TITLE
ci(publish): use yarn instead of npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           cp .github/package.json package.json
           DATE=$(date +%Y%m%d%H%M%S)
-          publish=(npm publish --access=public)
+          publish=(yarn publish --access=public --no-git-tag-version --non-interactive)
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
             publish+=(--tag latest)
           else


### PR DESCRIPTION
Use `yarn` instead of `npm` to publish package, because `npm` doesn't support setting preid on the version.

I doesn't fit well in this ecosystem.. 😢 