### PR TITLE
Feat/batch messages

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,7 +40,6 @@ linters:
     - nakedret
     - nestif
     - nilerr
-    - nilnil
     - noctx
     - nolintlint
     - prealloc

--- a/README.md
+++ b/README.md
@@ -60,10 +60,11 @@ Global Flags:
       --gas-limit uint        Gas limit (default 200000)
       --grpc-address string   The grpc okp4 server url (default "127.0.0.1:9090")
       --memo string           The memo description (default "Sent by økp4 faucet")
-      --mnemonic string       
+      --mnemonic string
       --no-tls                No encryption with the GRPC endpoint
       --prefix string         Address prefix (default "okp4")
       --tls-skip-verify       Encryption with the GRPC endpoint but skip certificates verification
+      --tx-timeout duration   Transaction timeout (default 5s)
 ```
 
 #### Start
@@ -76,6 +77,7 @@ Usage:
 
 Flags:
       --address string              graphql api address (default ":8080")
+      --batch-window duration       Batch temporal window, can be seen a the minimum duration between too transactions. (default 8s)
       --captcha                     enable captcha verification
       --captcha-min-score float     set Captcha min score (default 0.5)
       --captcha-secret string       set Captcha secret
@@ -92,15 +94,16 @@ Global Flags:
       --gas-limit uint        Gas limit (default 200000)
       --grpc-address string   The grpc okp4 server url (default "127.0.0.1:9090")
       --memo string           The memo description (default "Sent by økp4 faucet")
-      --mnemonic string       
+      --mnemonic string
       --no-tls                No encryption with the GRPC endpoint
       --prefix string         Address prefix (default "okp4")
       --tls-skip-verify       Encryption with the GRPC endpoint but skip certificates verification
+      --tx-timeout duration   Transaction timeout (default 5s)
 ```
 
 ### GraphQL
 
-Start GraphQL server with captcha verification for the send token mutation.
+Start GraphQL server with captcha verification for the send token mutation and subscription.
 
 ```shell
 cosmos-faucet start --captcha --captcha-secret $CAPCTHA_SECRET

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -12,4 +12,5 @@ const (
 	FlagGasLimit      = "gas-limit"
 	FlagNoTLS         = "no-tls"
 	FlagTLSSkipVerify = "tls-skip-verify"
+	FlagTxTimeout     = "tx-timeout"
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"okp4/cosmos-faucet/pkg"
 
@@ -50,6 +51,7 @@ func Execute() {
 		FlagTLSSkipVerify,
 		false,
 		"Encryption with the GRPC endpoint but skip certificates verification")
+	rootCmd.PersistentFlags().DurationVar(&config.TxTimeout, FlagTxTimeout, 5*time.Second, "Transaction timeout")
 
 	err := rootCmd.Execute()
 	if err != nil {

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"okp4/cosmos-faucet/pkg/client"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -13,7 +14,7 @@ func NewSendCommand() *cobra.Command {
 		Short: "Send tokens to a given address",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			send := make(chan bool)
+			send := make(chan *client.TriggerTx)
 			faucet, err := client.NewFaucet(config, send)
 			if err != nil {
 				return err
@@ -27,7 +28,7 @@ func NewSendCommand() *cobra.Command {
 				return err
 			}
 
-			send <- true
+			send <- client.MakeTriggerTx(client.WithDeadline(time.Now().Add(5 * time.Second)))
 
 			return err
 		},

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"okp4/cosmos-faucet/pkg/client"
 
 	"github.com/spf13/cobra"
@@ -14,12 +13,13 @@ func NewSendCommand() *cobra.Command {
 		Short: "Send tokens to a given address",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			faucet, err := client.NewFaucet(config, nil)
+			send := make(chan bool)
+			faucet, err := client.NewFaucet(config, send)
 			if err != nil {
 				return err
 			}
 
-			defer func(faucet client.Faucet) {
+			defer func(faucet *client.Faucet) {
 				_ = faucet.Close()
 			}(faucet)
 
@@ -27,7 +27,7 @@ func NewSendCommand() *cobra.Command {
 				return err
 			}
 
-			_, err = faucet.SubmitTx(context.Background())
+			send <- true
 
 			return err
 		},

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -28,7 +28,7 @@ func NewSendCommand() *cobra.Command {
 				return err
 			}
 
-			send <- client.MakeTriggerTx(client.WithDeadline(time.Now().Add(5 * time.Second)))
+			send <- client.MakeTriggerTx(client.WithDeadline(time.Now().Add(config.TxTimeout)))
 
 			return err
 		},

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-
 	"okp4/cosmos-faucet/pkg/client"
 
 	"github.com/spf13/cobra"
@@ -15,7 +14,7 @@ func NewSendCommand() *cobra.Command {
 		Short: "Send tokens to a given address",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			faucet, err := client.NewFaucet(config)
+			faucet, err := client.NewFaucet(config, nil)
 			if err != nil {
 				return err
 			}
@@ -24,7 +23,11 @@ func NewSendCommand() *cobra.Command {
 				_ = faucet.Close()
 			}(faucet)
 
-			_, err = faucet.SendTxMsg(context.Background(), args[0])
+			if err := faucet.Send(args[0]); err != nil {
+				return err
+			}
+
+			_, err = faucet.SubmitTx(context.Background())
 
 			return err
 		},

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -28,10 +28,12 @@ func NewStartCommand() *cobra.Command {
 		Use:   "start",
 		Short: "Start the GraphQL api",
 		Run: func(cmd *cobra.Command, args []string) {
-			faucet, err := client.NewFaucet(config)
+			faucet, err := client.NewFaucet(config, nil)
 			if err != nil {
 				log.Fatal().Err(err).Msg("Failed create a new faucet instance")
 			}
+
+			faucet.Start()
 
 			defer func(faucet client.Faucet) {
 				_ = faucet.Close()

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -41,9 +41,7 @@ func NewStartCommand() *cobra.Command {
 				log.Fatal().Err(err).Msg("Failed create a new faucet instance")
 			}
 
-			faucet.Start()
-
-			defer func(faucet client.Faucet) {
+			defer func(faucet *client.Faucet) {
 				_ = faucet.Close()
 				log.Info().Msg("Server stopped")
 			}(faucet)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -23,6 +23,7 @@ const (
 var serverConfig server.Config
 
 // NewStartCommand returns a CLI command to start the REST api allowing to send tokens.
+// nolint: funlen
 func NewStartCommand() *cobra.Command {
 	var addr string
 	var batchWindow time.Duration

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"okp4/cosmos-faucet/internal/server"
 	"okp4/cosmos-faucet/pkg/client"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -28,7 +29,14 @@ func NewStartCommand() *cobra.Command {
 		Use:   "start",
 		Short: "Start the GraphQL api",
 		Run: func(cmd *cobra.Command, args []string) {
-			faucet, err := client.NewFaucet(config, nil)
+			triggerTxChan := make(chan bool)
+			go func() {
+				for range time.Tick(5 * time.Second) {
+					triggerTxChan <- true
+				}
+			}()
+
+			faucet, err := client.NewFaucet(config, triggerTxChan)
 			if err != nil {
 				log.Fatal().Err(err).Msg("Failed create a new faucet instance")
 			}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -32,7 +32,7 @@ func NewStartCommand() *cobra.Command {
 			triggerTxChan := make(chan *client.TriggerTx)
 			go func() {
 				for range time.Tick(5 * time.Second) {
-					triggerTxChan <- client.MakeTriggerTx(client.WithDeadline(time.Now().Add(5 * time.Second)))
+					triggerTxChan <- client.MakeTriggerTx(client.WithDeadline(time.Now().Add(config.TxTimeout)))
 				}
 			}()
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -29,10 +29,10 @@ func NewStartCommand() *cobra.Command {
 		Use:   "start",
 		Short: "Start the GraphQL api",
 		Run: func(cmd *cobra.Command, args []string) {
-			triggerTxChan := make(chan bool)
+			triggerTxChan := make(chan *client.TriggerTx)
 			go func() {
 				for range time.Tick(5 * time.Second) {
-					triggerTxChan <- true
+					triggerTxChan <- client.MakeTriggerTx(client.WithDeadline(time.Now().Add(5 * time.Second)))
 				}
 			}()
 

--- a/graph/generated/generated.go
+++ b/graph/generated/generated.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"okp4/cosmos-faucet/graph/model"
 	"okp4/cosmos-faucet/pkg"
 	"strconv"
@@ -39,6 +40,7 @@ type Config struct {
 type ResolverRoot interface {
 	Mutation() MutationResolver
 	Query() QueryResolver
+	Subscription() SubscriptionResolver
 }
 
 type DirectiveRoot struct {
@@ -63,6 +65,10 @@ type ComplexityRoot struct {
 		Configuration func(childComplexity int) int
 	}
 
+	Subscription struct {
+		Send func(childComplexity int, input model.SendInput) int
+	}
+
 	TxResponse struct {
 		Code      func(childComplexity int) int
 		GasUsed   func(childComplexity int) int
@@ -77,6 +83,9 @@ type MutationResolver interface {
 }
 type QueryResolver interface {
 	Configuration(ctx context.Context) (*model.Configuration, error)
+}
+type SubscriptionResolver interface {
+	Send(ctx context.Context, input model.SendInput) (<-chan *model.TxResponse, error)
 }
 
 type executableSchema struct {
@@ -162,6 +171,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Configuration(childComplexity), true
 
+	case "Subscription.send":
+		if e.complexity.Subscription.Send == nil {
+			break
+		}
+
+		args, err := ec.field_Subscription_send_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Subscription.Send(childComplexity, args["input"].(model.SendInput)), true
+
 	case "TxResponse.code":
 		if e.complexity.TxResponse.Code == nil {
 			break
@@ -240,6 +261,23 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 				Data: buf.Bytes(),
 			}
 		}
+	case ast.Subscription:
+		next := ec._Subscription(ctx, rc.Operation.SelectionSet)
+
+		var buf bytes.Buffer
+		return func(ctx context.Context) *graphql.Response {
+			buf.Reset()
+			data := next(ctx)
+
+			if data == nil {
+				return nil
+			}
+			data.MarshalGQL(&buf)
+
+			return &graphql.Response{
+				Data: buf.Bytes(),
+			}
+		}
 
 	default:
 		return graphql.OneShot(graphql.ErrorResponse(ctx, "unsupported GraphQL operation"))
@@ -304,6 +342,19 @@ type TxResponse {
     hash: String!
     """Description of error if available."""
     rawLog: String
+}
+
+"""List of all subscriptions"""
+type Subscription {
+    """
+    Send the configured amount of token to the given address.
+
+    By opening the subscription the send message is added to a queue, once the transaction is successfully submitted
+    with all the queued messages it'll return the corresponding before closing the stream. A successful submission does
+    not mean it has been successfully written in a block, it is the client's responsibility to make additional checks
+    through the transaction's code and hash.
+    """
+    send(input: SendInput!): TxResponse!
 }
 
 """List of all mutations"""
@@ -378,6 +429,21 @@ func (ec *executionContext) field_Query___type_args(ctx context.Context, rawArgs
 		}
 	}
 	args["name"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Subscription_send_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 model.SendInput
+	if tmp, ok := rawArgs["input"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
+		arg0, err = ec.unmarshalNSendInput2okp4ᚋcosmosᚑfaucetᚋgraphᚋmodelᚐSendInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["input"] = arg0
 	return args, nil
 }
 
@@ -964,6 +1030,87 @@ func (ec *executionContext) fieldContext_Query___schema(ctx context.Context, fie
 			}
 			return nil, fmt.Errorf("no field named %q was found under type __Schema", field.Name)
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Subscription_send(ctx context.Context, field graphql.CollectedField) (ret func(ctx context.Context) graphql.Marshaler) {
+	fc, err := ec.fieldContext_Subscription_send(ctx, field)
+	if err != nil {
+		return nil
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = nil
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Subscription().Send(rctx, fc.Args["input"].(model.SendInput))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return nil
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return nil
+	}
+	return func(ctx context.Context) graphql.Marshaler {
+		select {
+		case res, ok := <-resTmp.(<-chan *model.TxResponse):
+			if !ok {
+				return nil
+			}
+			return graphql.WriterFunc(func(w io.Writer) {
+				w.Write([]byte{'{'})
+				graphql.MarshalString(field.Alias).MarshalGQL(w)
+				w.Write([]byte{':'})
+				ec.marshalNTxResponse2ᚖokp4ᚋcosmosᚑfaucetᚋgraphᚋmodelᚐTxResponse(ctx, field.Selections, res).MarshalGQL(w)
+				w.Write([]byte{'}'})
+			})
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (ec *executionContext) fieldContext_Subscription_send(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Subscription",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "code":
+				return ec.fieldContext_TxResponse_code(ctx, field)
+			case "gasUsed":
+				return ec.fieldContext_TxResponse_gasUsed(ctx, field)
+			case "gasWanted":
+				return ec.fieldContext_TxResponse_gasWanted(ctx, field)
+			case "hash":
+				return ec.fieldContext_TxResponse_hash(ctx, field)
+			case "rawLog":
+				return ec.fieldContext_TxResponse_rawLog(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TxResponse", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Subscription_send_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
 	}
 	return fc, nil
 }
@@ -3173,6 +3320,26 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 	return out
 }
 
+var subscriptionImplementors = []string{"Subscription"}
+
+func (ec *executionContext) _Subscription(ctx context.Context, sel ast.SelectionSet) func(ctx context.Context) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, subscriptionImplementors)
+	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+		Object: "Subscription",
+	})
+	if len(fields) != 1 {
+		ec.Errorf(ctx, "must subscribe to exactly one stream")
+		return nil
+	}
+
+	switch fields[0].Name {
+	case "send":
+		return ec._Subscription_send(ctx, fields[0])
+	default:
+		panic("unknown field " + strconv.Quote(fields[0].Name))
+	}
+}
+
 var txResponseImplementors = []string{"TxResponse"}
 
 func (ec *executionContext) _TxResponse(ctx context.Context, sel ast.SelectionSet, obj *model.TxResponse) graphql.Marshaler {
@@ -3636,6 +3803,20 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) marshalNTxResponse2okp4ᚋcosmosᚑfaucetᚋgraphᚋmodelᚐTxResponse(ctx context.Context, sel ast.SelectionSet, v model.TxResponse) graphql.Marshaler {
+	return ec._TxResponse(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNTxResponse2ᚖokp4ᚋcosmosᚑfaucetᚋgraphᚋmodelᚐTxResponse(ctx context.Context, sel ast.SelectionSet, v *model.TxResponse) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TxResponse(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNUInt642uint64(ctx context.Context, v interface{}) (uint64, error) {

--- a/graph/resolver.go
+++ b/graph/resolver.go
@@ -10,6 +10,6 @@ import (
 // It serves as dependency injection for your app, add any dependencies you require here.
 
 type Resolver struct {
-	Faucet          client.Faucet
+	Faucet          *client.Faucet
 	CaptchaResolver captcha.Resolver
 }

--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -41,9 +41,13 @@ type TxResponse {
 """List of all mutations"""
 type Mutation {
     """
-    Send the configured amount of token to the given address.
+    Send the configured amount of token to the given address, returning nothing as the transaction is made
+    asynchronously. A successful invocation means that the send operation is queued and will be processed, but it'll
+    does not necessary lead to a successful transaction.
+
+    For clients needing information on the underlying transaction state, consider using the `send` subscription.
     """
-    send(input: SendInput!): TxResponse!
+    send(input: SendInput!): Void
 }
 
 """Represent the actual server configuration"""

--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -10,6 +10,9 @@ scalar Long
 """An unsigned 64-bit integer"""
 scalar UInt64
 
+"""Represent a void return type, representing no value"""
+scalar Void
+
 """All inputs needed to send token to a given address"""
 input SendInput {
     """Captcha token"""

--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -38,6 +38,19 @@ type TxResponse {
     rawLog: String
 }
 
+"""List of all subscriptions"""
+type Subscription {
+    """
+    Send the configured amount of token to the given address.
+
+    By opening the subscription the send message is added to a queue, once the transaction is successfully submitted
+    with all the queued messages it'll return the corresponding before closing the stream. A successful submission does
+    not mean it has been successfully written in a block, it is the client's responsibility to make additional checks
+    through the transaction's code and hash.
+    """
+    send(input: SendInput!): TxResponse!
+}
+
 """List of all mutations"""
 type Mutation {
     """

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -18,7 +18,7 @@ func (r *mutationResolver) Send(ctx context.Context, input model.SendInput) (*st
 	}
 
 	if err := r.Faucet.Send(input.ToAddress); err != nil {
-		log.Err(err).Str("toAddress", input.ToAddress).Msg("Could not register send request.")
+		log.Err(err).Str("toAddress", input.ToAddress).Msg("Could not register send request")
 		return nil, err
 	}
 
@@ -39,11 +39,46 @@ func (r *queryResolver) Configuration(ctx context.Context) (*model.Configuration
 	}, nil
 }
 
+// Send is the resolver for the send field.
+func (r *subscriptionResolver) Send(ctx context.Context, input model.SendInput) (<-chan *model.TxResponse, error) {
+	if err := r.CaptchaResolver.CheckRecaptcha(ctx, input.CaptchaToken); err != nil {
+		return nil, err
+	}
+
+	if err := r.Faucet.Send(input.ToAddress); err != nil {
+		log.Err(err).Str("toAddress", input.ToAddress).Msg("Could not register send request")
+		return nil, err
+	}
+
+	log.Info().Str("toAddress", input.ToAddress).Msg("Register send request")
+
+	rawTxResponseChan := r.Faucet.Subscribe()
+	txResponseChan := make(chan *model.TxResponse)
+	go func() {
+		for rawTx := range rawTxResponseChan {
+			txResponseChan <- &model.TxResponse{
+				Hash:      rawTx.TxHash,
+				Code:      int(rawTx.Code),
+				RawLog:    &rawTx.RawLog,
+				GasWanted: rawTx.GasWanted,
+				GasUsed:   rawTx.GasUsed,
+			}
+		}
+		close(txResponseChan)
+	}()
+
+	return txResponseChan, nil
+}
+
 // Mutation returns generated.MutationResolver implementation.
 func (r *Resolver) Mutation() generated.MutationResolver { return &mutationResolver{r} }
 
 // Query returns generated.QueryResolver implementation.
 func (r *Resolver) Query() generated.QueryResolver { return &queryResolver{r} }
 
+// Subscription returns generated.SubscriptionResolver implementation.
+func (r *Resolver) Subscription() generated.SubscriptionResolver { return &subscriptionResolver{r} }
+
 type mutationResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
+type subscriptionResolver struct{ *Resolver }

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -12,18 +12,18 @@ import (
 )
 
 // Send is the resolver for the send field.
-func (r *mutationResolver) Send(ctx context.Context, input model.SendInput) (*string, error) {
-	if err := r.CaptchaResolver.CheckRecaptcha(ctx, input.CaptchaToken); err != nil {
-		return nil, err
+func (r *mutationResolver) Send(ctx context.Context, input model.SendInput) (void *string, err error) {
+	if err = r.CaptchaResolver.CheckRecaptcha(ctx, input.CaptchaToken); err != nil {
+		return
 	}
 
-	if err := r.Faucet.Send(input.ToAddress); err != nil {
+	if err = r.Faucet.Send(input.ToAddress); err != nil {
 		log.Err(err).Str("toAddress", input.ToAddress).Msg("Could not register send request")
-		return nil, err
+		return
 	}
 
 	log.Info().Str("toAddress", input.ToAddress).Msg("Register send request")
-	return nil, nil
+	return
 }
 
 // Configuration is the resolver for the configuration field.

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -45,14 +45,13 @@ func (r *subscriptionResolver) Send(ctx context.Context, input model.SendInput) 
 		return nil, err
 	}
 
-	if err := r.Faucet.Send(input.ToAddress); err != nil {
+	rawTxResponseChan, err := r.Faucet.Subscribe(input.ToAddress)
+	if err != nil {
 		log.Err(err).Str("toAddress", input.ToAddress).Msg("Could not register send request")
 		return nil, err
 	}
 
 	log.Info().Str("toAddress", input.ToAddress).Msg("Register send request")
-
-	rawTxResponseChan := r.Faucet.Subscribe()
 	txResponseChan := make(chan *model.TxResponse)
 	go func() {
 		for rawTx := range rawTxResponseChan {

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -12,7 +12,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func (r *mutationResolver) Send(ctx context.Context, input model.SendInput) (*model.TxResponse, error) {
+// Send is the resolver for the send field.
+func (r *mutationResolver) Send(ctx context.Context, input model.SendInput) (*string, error) {
 	if err := r.CaptchaResolver.CheckRecaptcha(ctx, input.CaptchaToken); err != nil {
 		return nil, err
 	}
@@ -48,9 +49,10 @@ func (r *mutationResolver) Send(ctx context.Context, input model.SendInput) (*mo
 			Msgf("transaction is not successful")
 	}
 
-	return response, nil
+	return nil, nil
 }
 
+// Configuration is the resolver for the configuration field.
 func (r *queryResolver) Configuration(ctx context.Context) (*model.Configuration, error) {
 	return &model.Configuration{
 		ChainID:    r.Faucet.GetConfig().ChainID,

--- a/graph/schema.resolvers_test.go
+++ b/graph/schema.resolvers_test.go
@@ -2,8 +2,6 @@ package graph
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"okp4/cosmos-faucet/pkg/captcha"
 	"testing"
 
@@ -13,38 +11,10 @@ import (
 	"okp4/cosmos-faucet/pkg/client"
 
 	gql "github.com/99designs/gqlgen/client"
-	"github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/99designs/gqlgen/graphql/handler"
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/wingyplus/must"
-)
-
-const (
-	graphQLRequestSendWithIncorrectAddress = `
-                mutation {
-                    send(input: {
-                        captchaToken: "token"
-                        toAddress: "wrong formatted address"
-                    }) {
-                        hash
-                    }
-                }
-                `
-	graphQLRequestSend = `
-                mutation {
-                    send(input: {
-                        captchaToken: "token"
-                        toAddress: "okp41jse8senm9hcvydhl8v9x47kfe5z82zmwtw8jvj"
-                    }) {
-                        hash
-                        code
-                        rawLog
-                        gasWanted
-                        gasUsed
-                    }
-                }`
 )
 
 var config = pkg.Config{
@@ -59,24 +29,6 @@ var config = pkg.Config{
 	Mnemonic:    "nasty random alter chronic become keen stadium test chaos fashion during claim rug thing trade swap bleak shuffle bronze gun tobacco length aim hazard",
 }
 
-type mockFaucet struct {
-	config    pkg.Config
-	withError bool
-}
-
-func (f mockFaucet) GetConfig() pkg.Config {
-	return config
-}
-
-func (f mockFaucet) GetFromAddr() types.AccAddress {
-	bech32, _ := types.AccAddressFromBech32("okp41jse8senm9hcvydhl8v9x47kfe5z82zmwtw8jvj")
-	return bech32
-}
-
-func (f mockFaucet) Close() error {
-	panic("implement me")
-}
-
 type mockCaptchaResolver struct{}
 
 func newMockCaptchaResolver() captcha.Resolver {
@@ -87,102 +39,9 @@ func (r mockCaptchaResolver) CheckRecaptcha(_ context.Context, _ *string) error 
 	return nil
 }
 
-func (f mockFaucet) SendTxMsg(_ context.Context, _ string) (*types.TxResponse, error) {
-	var code uint32
-	if f.withError {
-		code = 12
-	} else {
-		code = 0
-	}
-
-	return &types.TxResponse{
-		Height:    0,
-		TxHash:    "HASH",
-		Codespace: "",
-		Code:      code,
-		Data:      "",
-		RawLog:    "",
-		Logs:      nil,
-		Info:      "",
-		GasWanted: 10,
-		GasUsed:   20,
-		Tx:        nil,
-		Timestamp: "",
-		Events:    nil,
-	}, nil
-}
-
-func TestMutationResolver_Send(t *testing.T) {
-	cases := []struct {
-		name              string
-		request           string
-		faucet            client.Faucet
-		expectedError     string
-		expectedCode      int
-		expectedHash      string
-		expectedGasUsed   int64
-		expectedGasWanted int64
-	}{
-		{
-			name:          "a Faucet service configured to succeed and a graphQL 'send' mutation request with an incorrect address",
-			request:       graphQLRequestSendWithIncorrectAddress,
-			faucet:        must.Must(client.NewFaucet(config)),
-			expectedError: "decoding bech32 failed: invalid character in string: ' '",
-		},
-		{
-			name:              "a Faucet service configured to succeed and a correct graphQL 'send' mutation",
-			request:           graphQLRequestSend,
-			faucet:            mockFaucet{config: config},
-			expectedHash:      "HASH",
-			expectedGasUsed:   20,
-			expectedGasWanted: 10,
-		},
-		{
-			name:              "a Faucet service configured to fail and a correct graphQL 'send' mutation",
-			request:           graphQLRequestSend,
-			faucet:            mockFaucet{config: config, withError: true},
-			expectedError:     `transaction is not successful:  (code: 12)","path":["send"]}]`,
-			expectedCode:      12,
-			expectedHash:      "HASH",
-			expectedGasUsed:   20,
-			expectedGasWanted: 10,
-		},
-	}
-
-	for n, c := range cases {
-		Convey(fmt.Sprintf("Given %s (case %d)", c.name, n), t, func() {
-			srv := gql.New(handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: &Resolver{Faucet: c.faucet, CaptchaResolver: newMockCaptchaResolver()}})))
-
-			Convey("When posting the graphQL request", func() {
-				var result struct {
-					Send model.TxResponse
-				}
-				err := srv.Post(c.request, &result)
-
-				Convey("Then the request should meet expectations", func() {
-					if c.expectedError != "" {
-						So(err, ShouldNotBeNil)
-
-						var jsonError gql.RawJsonError
-						So(errors.As(err, &jsonError), ShouldBeTrue)
-						So(jsonError.Error(), ShouldContainSubstring, c.expectedError)
-					} else {
-						So(err, ShouldBeNil)
-					}
-
-					So(result.Send.Code, ShouldEqual, c.expectedCode)
-					So(result.Send.Hash, ShouldEqual, c.expectedHash)
-					So(result.Send.GasUsed, ShouldEqual, c.expectedGasUsed)
-					So(result.Send.GasWanted, ShouldEqual, c.expectedGasWanted)
-				})
-			})
-		})
-	}
-}
-
 func TestQueryResolver_Configuration(t *testing.T) {
 	Convey("Given a faucet service configured to succeed", t, func() {
-		faucet := must.Must(client.NewFaucet(config))
+		faucet := must.Must(client.NewFaucet(config, nil))
 
 		srv := gql.New(handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: &Resolver{Faucet: faucet, CaptchaResolver: newMockCaptchaResolver()}})))
 

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -11,7 +11,6 @@ import (
 )
 
 func (s *httpServer) createRoutes(config Config) {
-	s.router.Use(handlers.PrometheusMiddleware)
 	s.router.Path("/").
 		HandlerFunc(playground.Handler("GraphQL playground", "/graphql")).
 		Methods("GET")

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1,13 +1,20 @@
 package server
 
 import (
+	"net/http"
 	"okp4/cosmos-faucet/graph"
 	"okp4/cosmos-faucet/graph/generated"
 	"okp4/cosmos-faucet/internal/server/handlers"
 	"okp4/cosmos-faucet/pkg/captcha"
+	"time"
 
-	graphql "github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql"
+	graphqlserver "github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/extension"
+	"github.com/99designs/gqlgen/graphql/handler/lru"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/99designs/gqlgen/graphql/playground"
+	"github.com/gorilla/websocket"
 )
 
 func (s *httpServer) createRoutes(config Config) {
@@ -16,7 +23,7 @@ func (s *httpServer) createRoutes(config Config) {
 		Methods("GET")
 	s.router.Path("/graphql").
 		Handler(
-			graphql.NewDefaultServer(
+			newGraphQLServer(
 				generated.NewExecutableSchema(generated.Config{
 					Resolvers: &graph.Resolver{
 						Faucet:          config.Faucet,
@@ -36,4 +43,30 @@ func (s *httpServer) createRoutes(config Config) {
 			Handler(handlers.NewMetricsRequestHandler()).
 			Methods("GET")
 	}
+}
+
+func newGraphQLServer(schema graphql.ExecutableSchema) http.Handler {
+	srv := graphqlserver.New(schema)
+
+	srv.AddTransport(transport.Websocket{
+		KeepAlivePingInterval: 10 * time.Second,
+		Upgrader: websocket.Upgrader{
+			CheckOrigin: func(r *http.Request) bool {
+				return true
+			},
+		},
+	})
+	srv.AddTransport(transport.Options{})
+	srv.AddTransport(transport.GET{})
+	srv.AddTransport(transport.POST{})
+	srv.AddTransport(transport.MultipartForm{})
+
+	srv.SetQueryCache(lru.New(1000))
+
+	srv.Use(extension.Introspection{})
+	srv.Use(extension.AutomaticPersistedQuery{
+		Cache: lru.New(100),
+	})
+
+	return srv
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -37,6 +37,6 @@ func NewServer(config Config) HTTPServer {
 
 // Start starts the http server on specified address.
 func (s httpServer) Start(address string) {
-	log.Info().Msgf("Server listening at %s", address)
+	log.Info().Msgf("\U0001F9BB Server listening at %s", address)
 	log.Fatal().Err(http.ListenAndServe(address, s.router)).Msg("Server listening stopped")
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,7 +13,7 @@ import (
 type Config struct {
 	EnableMetrics bool `mapstructure:"metrics"`
 	EnableHealth  bool `mapstructure:"health"`
-	Faucet        client.Faucet
+	Faucet        *client.Faucet
 	CaptchaConf   captcha.ResolverConfig
 }
 

--- a/pkg/client/faucet.go
+++ b/pkg/client/faucet.go
@@ -84,11 +84,19 @@ func (f *faucet) Start() {
 			if err != nil {
 				log.Err(err).Int("msgCount", msgCount).Msg("Could not submit transaction")
 			} else if resp != nil {
-				log.Info().
-					Int("messageCount", msgCount).
-					Str("txHash", resp.TxHash).
-					Uint32("txCode", resp.Code).
-					Msg("Successfully submit transaction")
+				if resp.Code != 0 {
+					log.Warn().
+						Int("messageCount", msgCount).
+						Interface("tx", resp).
+						Msg("Transaction submitted with non 0 code")
+
+				} else {
+					log.Info().
+						Int("messageCount", msgCount).
+						Str("txHash", resp.TxHash).
+						Uint32("txCode", resp.Code).
+						Msg("Successfully submit transaction")
+				}
 			} else {
 				log.Info().Msg("No message to submit")
 			}

--- a/pkg/client/faucet.go
+++ b/pkg/client/faucet.go
@@ -116,15 +116,15 @@ func (f *Faucet) handleTriggerTx(trigger *TriggerTx) {
 
 	msgCount := f.pool.Size()
 	resp, err := f.pool.Submit(ctx)
-	if err != nil {
+	switch {
+	case err != nil:
 		log.Err(err).Int("msgCount", msgCount).Msg("❌ Could not submit transaction")
-	} else if resp != nil {
+	case resp != nil:
 		if resp.Code != 0 {
 			log.Warn().
 				Int("messageCount", msgCount).
 				Interface("tx", resp).
 				Msg("😞 Transaction submitted with non 0 code")
-
 		} else {
 			log.Info().
 				Int("messageCount", msgCount).
@@ -132,7 +132,7 @@ func (f *Faucet) handleTriggerTx(trigger *TriggerTx) {
 				Uint32("txCode", resp.Code).
 				Msg("🚀 Successfully submit transaction")
 		}
-	} else {
+	default:
 		log.Info().Msg("😥 No message to submit")
 	}
 }
@@ -177,7 +177,13 @@ func (f *Faucet) makeSendMsg(addr string) (types.Msg, error) {
 	), nil
 }
 
-func makeTxSubmitter(config pkg.Config, txConfig client.TxConfig, grpcConn *grpc.ClientConn, privKey crypto.PrivKey, addr types.AccAddress) TxSubmitter {
+func makeTxSubmitter(
+	config pkg.Config,
+	txConfig client.TxConfig,
+	grpcConn *grpc.ClientConn,
+	privKey crypto.PrivKey,
+	addr types.AccAddress,
+) TxSubmitter {
 	return func(ctx context.Context, msgs []types.Msg) (*types.TxResponse, error) {
 		txBuilder, err := cosmos.BuildUnsignedTx(config, txConfig, msgs)
 		if err != nil {

--- a/pkg/client/faucet.go
+++ b/pkg/client/faucet.go
@@ -99,14 +99,14 @@ func NewFaucet(config pkg.Config, triggerTxChan <-chan *TriggerTx) (*Faucet, err
 
 func (f *Faucet) start() {
 	go func() {
-		log.Info().Msg("Starting submit routine")
+		log.Info().Msg("🏃 Starting submit routine")
 		for trigger := range f.triggerTx {
 			if trigger.Deadline.After(time.Now()) {
 				f.handleTriggerTx(trigger)
 			}
 		}
 
-		log.Info().Msg("Stopping submit routine")
+		log.Info().Msg("🏁 Stopping submit routine")
 	}()
 }
 
@@ -117,23 +117,23 @@ func (f *Faucet) handleTriggerTx(trigger *TriggerTx) {
 	msgCount := f.pool.Size()
 	resp, err := f.pool.Submit(ctx)
 	if err != nil {
-		log.Err(err).Int("msgCount", msgCount).Msg("Could not submit transaction")
+		log.Err(err).Int("msgCount", msgCount).Msg("❌ Could not submit transaction")
 	} else if resp != nil {
 		if resp.Code != 0 {
 			log.Warn().
 				Int("messageCount", msgCount).
 				Interface("tx", resp).
-				Msg("Transaction submitted with non 0 code")
+				Msg("😞 Transaction submitted with non 0 code")
 
 		} else {
 			log.Info().
 				Int("messageCount", msgCount).
 				Str("txHash", resp.TxHash).
 				Uint32("txCode", resp.Code).
-				Msg("Successfully submit transaction")
+				Msg("🚀 Successfully submit transaction")
 		}
 	} else {
-		log.Info().Msg("No message to submit")
+		log.Info().Msg("😥 No message to submit")
 	}
 }
 

--- a/pkg/client/faucet.go
+++ b/pkg/client/faucet.go
@@ -25,7 +25,7 @@ type Faucet interface {
 	GetFromAddr() types.AccAddress
 	SubmitTx(ctx context.Context) (*types.TxResponse, error)
 	Send(addr string) error
-	Subscribe() <-chan *types.TxResponse
+	Subscribe(addr string) (<-chan *types.TxResponse, error)
 	Close() error
 }
 
@@ -163,11 +163,14 @@ func (f *faucet) Send(addr string) error {
 	return nil
 }
 
-func (f *faucet) Subscribe() <-chan *types.TxResponse {
+func (f *faucet) Subscribe(addr string) (<-chan *types.TxResponse, error) {
+	if err := f.Send(addr); err != nil {
+		return nil, err
+	}
 	txResponseChan := make(chan *types.TxResponse)
 	f.txResponseChans = append(f.txResponseChans, txResponseChan)
 
-	return txResponseChan
+	return txResponseChan, nil
 }
 
 func (f *faucet) Close() error {

--- a/pkg/client/faucet_test.go
+++ b/pkg/client/faucet_test.go
@@ -23,22 +23,18 @@ func TestNewFaucet(t *testing.T) {
 		}
 
 		Convey("When creating the faucet service", func() {
-			svc, err := NewFaucet(config)
+			svc, err := NewFaucet(config, nil)
 
 			Convey("Then the faucet should be successfully created with the provided configuration", func() {
 				So(svc, ShouldNotBeNil)
 				So(err, ShouldBeNil)
 
 				So(svc.GetConfig(), ShouldResemble, config)
-				So(svc.GetFromAddr().String(), ShouldEqual, "okp412wc7ts3fwaxkc7azjal0wsd434m0kwxr3c0aqn")
+				So(svc.fromAddress.String(), ShouldEqual, "okp412wc7ts3fwaxkc7azjal0wsd434m0kwxr3c0aqn")
 			})
 
 			Convey("And the GRPC connection should target the expected address", func() {
-				So(svc.(*faucet).grpcConn.Target(), ShouldEqual, grpcAddre)
-			})
-
-			Convey("And the private key should equal the expected byte sequence", func() {
-				So(svc.(*faucet).fromPrivKey.Bytes(), ShouldResemble, []byte{65, 73, 9, 173, 188, 203, 234, 54, 252, 7, 215, 139, 14, 198, 158, 151, 173, 0, 14, 41, 35, 110, 154, 38, 116, 168, 164, 167, 140, 151, 67, 113})
+				So(svc.grpcConn.Target(), ShouldEqual, grpcAddre)
 			})
 		})
 	})
@@ -52,7 +48,7 @@ func TestNewFaucet(t *testing.T) {
 		}
 
 		Convey("When creating the faucet service", func() {
-			faucet, err := NewFaucet(config)
+			faucet, err := NewFaucet(config, nil)
 
 			Convey("Then the faucet creation should fail", func() {
 				So(faucet, ShouldBeNil)

--- a/pkg/client/message_pool.go
+++ b/pkg/client/message_pool.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"sync"
 
 	"github.com/cosmos/cosmos-sdk/types"
@@ -17,7 +18,7 @@ type MessagePool struct {
 
 // TxSubmitter shall implement all the logic to build, sign and submit a transaction containing all the messages of the
 // pool.
-type TxSubmitter func([]types.Msg) (*types.TxResponse, error)
+type TxSubmitter func(context.Context, []types.Msg) (*types.TxResponse, error)
 
 // MessagePoolOption allow to configure a MessagePool.
 type MessagePoolOption func(pool *MessagePool)
@@ -77,7 +78,7 @@ func (pool *MessagePool) SubscribeMsg(msg types.Msg) <-chan *types.TxResponse {
 //
 // Warning: To avoid locking the MessagePool, the channels are closed in a separate routine which can lead to goroutine
 // leak if they are not consumed.
-func (pool *MessagePool) Submit() (*types.TxResponse, error) {
+func (pool *MessagePool) Submit(ctx context.Context) (*types.TxResponse, error) {
 	pool.lock()
 	defer func() {
 		pool.flush()
@@ -88,7 +89,7 @@ func (pool *MessagePool) Submit() (*types.TxResponse, error) {
 		return nil, nil
 	}
 
-	resp, err := pool.submitterFunc(pool.msgs)
+	resp, err := pool.submitterFunc(ctx, pool.msgs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/message_pool.go
+++ b/pkg/client/message_pool.go
@@ -1,0 +1,105 @@
+package client
+
+import (
+	"sync"
+
+	"github.com/cosmos/cosmos-sdk/types"
+)
+
+// MessagePool atomically manage a pool of messages waiting to be sent through a transaction. It also allows to
+// subscribe to the transaction response once submitted to receive it through a channel.
+type MessagePool struct {
+	mut         *sync.Mutex
+	txFunc      TxSubmitter
+	msgs        []*types.Msg
+	subscribers []chan *types.TxResponse
+}
+
+// TxSubmitter shall implement all the logic to build, sign and submit a transaction containing all the messages of the
+// pool.
+type TxSubmitter func([]*types.Msg) (*types.TxResponse, error)
+
+// MessagePoolOption allow to configure a MessagePool.
+type MessagePoolOption func(pool *MessagePool)
+
+// NewMessagePool initialize a new MessagePool instance, and configure it with the provided options.
+func NewMessagePool(opts ...MessagePoolOption) *MessagePool {
+	pool := &MessagePool{
+		mut: &sync.Mutex{},
+	}
+
+	for _, opt := range opts {
+		opt(pool)
+	}
+
+	return pool
+}
+
+// RegisterMsg atomically add the message in the pool.
+func (pool *MessagePool) RegisterMsg(msg *types.Msg) {
+	pool.lock()
+	defer pool.unlock()
+
+	pool.msgs = append(pool.msgs, msg)
+}
+
+// SubscribeMsg atomically add the message in the pool, it also returns a channel on which will be sent the
+// corresponding transaction response, see Submit for more information on how the channel is managed.
+func (pool *MessagePool) SubscribeMsg(msg *types.Msg) <-chan *types.TxResponse {
+	pool.lock()
+	defer pool.unlock()
+
+	pool.msgs = append(pool.msgs, msg)
+
+	txResponseChan := make(chan *types.TxResponse)
+	pool.subscribers = append(pool.subscribers, txResponseChan)
+
+	return txResponseChan
+}
+
+// Submit atomically submit a new transaction using configured the TxSubmitter embedding all the pooled messages and
+// empty the pool. If an error occur there is no retry on the concerned messages.
+//
+// The subscribed channels will be closed following the transaction response, if an error occur submitting the
+// transaction the channels are closed without any data.
+//
+// Warning: To avoid locking the MessagePool, the channels are closed in separate routines which can lead to goroutine
+// leak if they are not consumed.
+func (pool *MessagePool) Submit() error {
+	pool.lock()
+	defer func() {
+		pool.flush()
+		pool.unlock()
+	}()
+
+	resp, err := pool.txFunc(pool.msgs)
+	if err != nil {
+		return err
+	}
+
+	for _, subscriber := range pool.subscribers {
+		subscriber <- resp
+	}
+
+	return nil
+}
+
+func (pool *MessagePool) lock() {
+	pool.mut.Lock()
+}
+
+func (pool *MessagePool) unlock() {
+	pool.mut.Unlock()
+}
+
+func (pool *MessagePool) flush() {
+	for _, subscriber := range pool.subscribers {
+		subscriber := subscriber
+		go func() {
+			close(subscriber)
+		}()
+	}
+
+	pool.msgs = pool.msgs[:0]
+	pool.subscribers = pool.subscribers[:0]
+}

--- a/pkg/client/message_pool.go
+++ b/pkg/client/message_pool.go
@@ -82,6 +82,10 @@ func (pool *MessagePool) Submit() (*types.TxResponse, error) {
 		pool.unlock()
 	}()
 
+	if len(pool.msgs) == 0 {
+		return nil, nil
+	}
+
 	resp, err := pool.submitterFunc(pool.msgs)
 	if err != nil {
 		return nil, err

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -1,15 +1,18 @@
 package pkg
 
+import "time"
+
 type Config struct {
-	GrpcAddress   string `mapstructure:"grpc-address"`
-	Mnemonic      string `mapstructure:"mnemonic"`
-	ChainID       string `mapstructure:"chain-id"`
-	Denom         string `mapstructure:"denom"`
-	Prefix        string `mapstructure:"prefix"`
-	FeeAmount     int64  `mapstructure:"fee-amount"`
-	AmountSend    int64  `mapstructure:"amount-send"`
-	Memo          string `mapstructure:"memo"`
-	GasLimit      uint64 `mapstructure:"gas-limit"`
-	NoTLS         bool   `mapstructure:"no-tls"`
-	TLSSkipVerify bool   `mapstructure:"tls-skip-verify"`
+	GrpcAddress   string        `mapstructure:"grpc-address"`
+	Mnemonic      string        `mapstructure:"mnemonic"`
+	ChainID       string        `mapstructure:"chain-id"`
+	Denom         string        `mapstructure:"denom"`
+	Prefix        string        `mapstructure:"prefix"`
+	FeeAmount     int64         `mapstructure:"fee-amount"`
+	AmountSend    int64         `mapstructure:"amount-send"`
+	Memo          string        `mapstructure:"memo"`
+	GasLimit      uint64        `mapstructure:"gas-limit"`
+	NoTLS         bool          `mapstructure:"no-tls"`
+	TLSSkipVerify bool          `mapstructure:"tls-skip-verify"`
+	TxTimeout     time.Duration `mapstructure:"tx-timeout"`
 }

--- a/pkg/cosmos/tx.go
+++ b/pkg/cosmos/tx.go
@@ -10,15 +10,12 @@ import (
 	"github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
-	bank "github.com/cosmos/cosmos-sdk/x/bank/types"
 )
 
-func BuildUnsignedTx(config pkg.Config, txConfig sdk.TxConfig, fromAddr, toAddr types.AccAddress) (sdk.TxBuilder, error) {
-	msg := bank.NewMsgSend(fromAddr, toAddr, types.NewCoins(types.NewInt64Coin(config.Denom, config.AmountSend)))
-
+func BuildUnsignedTx(config pkg.Config, txConfig sdk.TxConfig, msgs []types.Msg) (sdk.TxBuilder, error) {
 	txBuilder := txConfig.NewTxBuilder()
 
-	err := txBuilder.SetMsgs(msg)
+	err := txBuilder.SetMsgs(msgs...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cosmos/tx_test.go
+++ b/pkg/cosmos/tx_test.go
@@ -28,11 +28,9 @@ func TestBuildUnsignedTx(t *testing.T) {
 			Memo:       "memo",
 			GasLimit:   2000,
 		}
-		fromAddr := types.AccAddress("okp4AAAAA")
-		toAddr := types.AccAddress("okp4BBB")
 
 		Convey("When building an unsigned transaction", func() {
-			unsignedTx, err := BuildUnsignedTx(config, newTxConfig(), fromAddr, toAddr)
+			unsignedTx, err := BuildUnsignedTx(config, newTxConfig(), nil)
 
 			Convey("Then the transaction should be successfully built", func() {
 				So(err, ShouldBeNil)
@@ -61,8 +59,6 @@ func TestSignTx(t *testing.T) {
 			Memo:       "memo",
 			GasLimit:   2000,
 		}
-		fromAddr := types.AccAddress("okp4AAAAA")
-		toAddr := types.AccAddress("okp4BBB")
 
 		Convey("When signing the transaction", func() {
 			signerData := signing.SignerData{
@@ -70,7 +66,7 @@ func TestSignTx(t *testing.T) {
 				AccountNumber: 10,
 				Sequence:      54,
 			}
-			tx, _ := BuildUnsignedTx(config, newTxConfig(), fromAddr, toAddr)
+			tx, _ := BuildUnsignedTx(config, newTxConfig(), nil)
 			err := SignTx(privKey, signerData, newTxConfig(), tx)
 
 			Convey("Then the transaction should be signed", func() {


### PR DESCRIPTION
Closes #77 

Solves the limitation of 1 possible send per block by batching multiple send messages in transactions, it actually uses a temporal window through which the faucet manages a pool of send messages, and batch them in a transaction at the end on the window. There is a transaction every x time, and between each transaction we bufferize the messages.

## 🔍 Details

To handle this batch mechanism a message pool has been implemented to ensure to atomicity of each operation on the pool.

The main impact of this change is that the transactions are dissociated from send mutations because of the asynchronous aspect, as a results we can no longer retrieve the transaction response on synchronous mutations. As a workaround, a `send` subscription has been introduced to be able to delayed the transaction response retrieval.

The handling of the batch window is not part of the `Faucet` type itself, the `Faucet` struct takes a triggering channel which is the responsibility of the client to trigger how he intend to. In the case a transaction takes a lot of times, to avoid accumulating trigger messages in the channel, every message (i.e. `TriggerTx`) contains a deadline time which will prevent making outdated transactions. In the case of an error submitting the transaction, there's currently no retry policy, that means every send messages it contains will not be fulfilled.

When requesting funds against the `Faucet` type, we now can use either:
- `Send`: Register a send message in the current pool.
- `Subscribe`: Register a send message in the current pool, and return a channel through which the transaction response will be delivered.

## ✍️  API changes

### `send` mutation ⚠️ BREAKING CHANGE

Synchronous transaction being no longer possible, the `send` mutation now returns nothing, to represents the empty response the `Void` scalar has been introduced.

### `send` subscription

To requests fund and asynchronously receive the related transaction update, the `send` subscription has been implemented through WebSocket, here is an example of its usage:
```graphql
subscription {
  send(input: {
    toAddress: "okp4194gct3alypwta35q2j5h4xwwqqzc8aq4ryumpc"
  }) {
    code
    gasUsed
    gasWanted
    hash
    rawLog
  }
}
```

## ⌨️ CLI new flags

The new flags are necessary to propose a logical behavior of the batching mechanism.

### `--tx-timeout` global flag

Set a timeout on a transaction submission, if it exceed to transaction process is stopped.

### `--batch-window` `start` command flag

Only available when running in server mode, set the duration between each transaction.

## 🤢 Caveats

### Goroutine leaks

Subscribing to the transaction response of a message added in the pool create a new channel for each message, to avoid locking the pool those channels are closed asynchronously in a separate goroutine, which can lead to goroutine leaks if one of the channels is never consumed.

### Metrics

The subscriptions being managed through websockets, the http middleware in charge of retrieving http metrics has been removed.

### Refactor considerations

Currently the `Faucet` struct is responsible for handling the grpc connection, but the logic implemented can be independent from the communication protocol. This make the tests complex to set up and prevent taking benefit of the logic implementing another protocol (e.g. rpc). I think by making the `Faucet` type independent of this layer could simplify the code, make it testable and allow its extensibility.

Another point is related to the asynchronous aspects brought in the batching mechanism, I think we could take benefit of the actor pattern. The interactions with the `Faucet` are currently mixed with direct calls and channel messages, but we could only operate with messages, as well as the communication between the faucet and the message pool, and the subscription response handling.

For these reasons, some tests have been deactivated, has it is now really difficult to test the resolvers with this lack of isolation, I think we can reintroduce them with a refactoring.